### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ And of course don't forget about your new social network in your `DIAuthConnecto
 
 ## Requirements
 
-- iOS 7.0+, xCode 7.0+
+- iOS 7.0+, Xcode 7.0+
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
